### PR TITLE
Fix: Remove Deprecated User Attributes from Model

### DIFF
--- a/orders/model/dependentmodels.go
+++ b/orders/model/dependentmodels.go
@@ -1,11 +1,11 @@
 package model
 
+
 type UserResponse struct {
-	ID       uint   `json:"user_id"`
 	Name     string `json:"name"`
 	Email    string `json:"email"`
-	Username string `json:"user_name"`
 }
+
 
 type ProductResponse struct {
 	ID          uint   `json:"product_id"`


### PR DESCRIPTION
This PR addresses breaking changes in the API by removing 'user_id' and 'user_name' from the UserResponse struct. These fields were removed from the API response, and thus need to be eliminated from the client-side model to maintain compatibility and prevent errors during runtime.