### PR TITLE
Fix: Update UserResponse Model to Match API Changes

### DIFF
--- a/orders/model/dependentmodels.go
+++ b/orders/model/dependentmodels.go
@@ -1,10 +1,9 @@
 package model
 
+// UserResponse represents the user details in the response.
 type UserResponse struct {
-	ID       uint   `json:"user_id"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
-	Username string `json:"user_name"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 type ProductResponse struct {


### PR DESCRIPTION
This update removes the 'user_id' and 'user_name' fields from the UserResponse model in the client codebase. These fields are no longer provided in the API response, causing previous client implementations to fail. The change ensures that the client aligns with the latest API definitions, preventing potential errors or undefined behaviors in order to maintain functional integrity.