### PR TITLE
Breaking Change: Remove user_id and user_name from UserResponse

### DIFF
--- a/orders/model/dependentmodels.go
+++ b/orders/model/dependentmodels.go
@@ -1,17 +1,17 @@
 package model
 
+
 type UserResponse struct {
-	ID       uint   `json:"user_id"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
-	Username string `json:"user_name"`
+  Name     string `json:"name"`
+  Email    string `json:"email"`
 }
 
+
 type ProductResponse struct {
-	ID          uint   `json:"product_id"`
-	Name        string `json:"product_name"`
-	Brand       string `json:"brand"`
-	Category    string `json:"category"`
-	SubCategory string `json:"sub_category"`
-	Price       uint   `json:"price"`
+  ID          uint   `json:"product_id"`
+  Name        string `json:"product_name"`
+  Brand       string `json:"brand"`
+  Category    string `json:"category"`
+  SubCategory string `json:"sub_category"`
+  Price       uint   `json:"price"`
 }


### PR DESCRIPTION
This change removes the 'user_id' and 'user_name' attributes from the UserResponse model due to update in the API service specifications. Clients relying on these attributes will face errors, hence the update is critical for maintaining compatibility with service responses.