### PR TITLE
Remove user_id and user_name from UserResponse

### DIFF
--- a/orders/model/dependentmodels.go
+++ b/orders/model/dependentmodels.go
@@ -1,12 +1,12 @@
 package model
 
+// UserResponse model used for user details.
 type UserResponse struct {
-	ID       uint   `json:"user_id"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
-	Username string `json:"user_name"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }
-
+ 
+// ProductResponse model used for product details.
 type ProductResponse struct {
 	ID          uint   `json:"product_id"`
 	Name        string `json:"product_name"`


### PR DESCRIPTION
This commit removes the user_id and user_name attributes from the UserResponse model to align with the updated API specification. Clients expecting these fields will encounter errors or undefined behavior, and this change ensures that the client code is compliant with the latest API response structure.