### PR TITLE
Remove Deprecated Attributes from UserResponse

### DIFF
--- a/orders/model/dependentmodels.go
+++ b/orders/model/dependentmodels.go
@@ -1,10 +1,8 @@
 package model
 
 type UserResponse struct {
-	ID       uint   `json:"user_id"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
-	Username string `json:"user_name"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 type ProductResponse struct {


### PR DESCRIPTION
This PR addresses the breaking changes caused by the removal of 'user_id' and 'user_name' from the UserResponse model. The changes are essential as clients that previously depended on these attributes will encounter errors. This update ensures compatibility with the updated API specification and maintains functionality in client applications.